### PR TITLE
Add asset directories and tweak gameplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The **data** folder keeps JSON data used by the game. Currently it stores
 `avatars.json` which defines hit points, attack values and other starting stats
 for each avatar class.
 
-The **assets** folder contains placeholders for future images. The `assets/avatars` directory currently only holds a README file, and `assets/items` is empty.
+The **assets** folder contains placeholders for future images. Use the `assets/avatars` directory for avatar art and `assets/items` for gear images.
 
 A `.gitignore` file is included to keep temporary files or editor caches out of
 version control.

--- a/assets/avatars/README.md
+++ b/assets/avatars/README.md
@@ -1,0 +1,1 @@
+# Avatar Images

--- a/assets/items/README.md
+++ b/assets/items/README.md
@@ -1,0 +1,1 @@
+# Item Images

--- a/game.js
+++ b/game.js
@@ -19,6 +19,11 @@ const itemNames={
         epic:['Phoenix Heart','Ancient Relic','Time Shard']
     }
 };
+const backgrounds={
+    Knight:'knight-bg',
+    Mage:'mage-bg',
+    Rogue:'rogue-bg'
+};
 let players=[];
 let current=0;
 let defending=[false,false];
@@ -129,6 +134,7 @@ document.querySelectorAll('.avatar-list button').forEach(btn=>{
             energy:avatars[avatar].energy,
             weapons:0,armor:0,artifacts:0,slots:avatars[avatar].slots
         };
+        document.body.className=backgrounds[avatar];
         showLoadout();
     });
 });
@@ -251,7 +257,7 @@ function updateTurn(){
 function attack(){
     const attacker=players[current];
     const defender=players[1-current];
-    if(Math.random()<0.1){
+    if(Math.random()<0.05){
         logMsg(`${defender.name} dodged the attack!`);
         defending[current]=false;
         endTurn();
@@ -276,13 +282,13 @@ function attack(){
 function defend(){
     defending[current]=true;
     const roll=Math.random();
-    if(roll<0.05){
+    if(roll<0.02){
         defendMult[current]=0;
         logMsg(`${players[current].name} prepares a perfect block!`);
-    }else if(roll<0.20){
+    }else if(roll<0.10){
         defendMult[current]=0.25;
         logMsg(`${players[current].name} braces to block 75% damage.`);
-    }else if(roll<0.50){
+    }else if(roll<0.35){
         defendMult[current]=0.5;
         logMsg(`${players[current].name} braces to block 50% damage.`);
     }else{
@@ -304,7 +310,7 @@ function special(){
     }
     attacker.energy-=attacker.cost;
     const defender=players[1-current];
-    if(Math.random()<0.1){
+    if(Math.random()<0.05){
         logMsg(`${defender.name} dodged the special attack!`);
         cooldown[current]=cooldownBase[current];
         defending[current]=false;
@@ -471,6 +477,15 @@ function randomItemName(type,rarity){
     return arr[Math.floor(Math.random()*arr.length)];
 }
 
+function previewItem(type){
+    const r=randomRarity();
+    document.getElementById('preview').textContent=`${randomItemName(type,r)} (${r})`;
+}
+
+function clearPreview(){
+    document.getElementById('preview').textContent='';
+}
+
 function buyWeapon(){
     if(coins>=10){
         coins-=10;
@@ -574,3 +589,9 @@ document.getElementById('shop-btn').onclick=()=>{
 };
 document.getElementById('back-btn').onclick=goBack;
 document.getElementById('boss-btn').onclick=startBossBattle;
+document.getElementById('buy-weapon-btn').addEventListener('mouseenter',()=>previewItem('weapon'));
+document.getElementById('buy-weapon-btn').addEventListener('mouseleave',clearPreview);
+document.getElementById('buy-armor-btn').addEventListener('mouseenter',()=>previewItem('armor'));
+document.getElementById('buy-armor-btn').addEventListener('mouseleave',clearPreview);
+document.getElementById('buy-artifact-btn').addEventListener('mouseenter',()=>previewItem('artifact'));
+document.getElementById('buy-artifact-btn').addEventListener('mouseleave',clearPreview);

--- a/index.html
+++ b/index.html
@@ -39,9 +39,10 @@
         </div>
         <div id="shop-screen" class="hidden">
             <h3>Shop</h3>
-            <button onclick="buyWeapon()">Buy Weapon (-10)</button>
-            <button onclick="buyArmor()">Buy Armor (-10)</button>
-            <button onclick="buyArtifact()">Buy Artifact (-20)</button>
+            <button id="buy-weapon-btn" onclick="buyWeapon()">Buy Weapon (-10)</button>
+            <button id="buy-armor-btn" onclick="buyArmor()">Buy Armor (-10)</button>
+            <button id="buy-artifact-btn" onclick="buyArtifact()">Buy Artifact (-20)</button>
+            <div id="preview" class="preview"></div>
             <button onclick="closeShop()">Close</button>
         </div>
         <button id="start-btn">Start Battle</button>

--- a/style.css
+++ b/style.css
@@ -6,13 +6,13 @@ body{
     text-align:center;
 }
 .container{
-    max-width:900px;
-    margin:30px auto;
+    max-width:none;
+    width:100%;
+    height:100vh;
+    margin:0;
     padding:20px;
+    box-sizing:border-box;
     background:#fff;
-    border-radius:10px;
-    border:4px solid #333;
-    box-shadow:0 0 10px #0003;
 }
 .hidden{display:none;}
 .avatar-list button{
@@ -96,4 +96,20 @@ body{
     padding:10px;
     border-radius:8px;
     background:#f7f7f7;
+}
+
+.preview{
+    margin-top:5px;
+    font-style:italic;
+}
+
+body.knight-bg{
+    background:linear-gradient(#d4d4d4,#a0a0a0);
+}
+body.mage-bg{
+    background:linear-gradient(#b0b0ff,#6a6aff);
+}
+body.rogue-bg{
+    background:linear-gradient(#888,#222);
+    color:#fff;
 }


### PR DESCRIPTION
## Summary
- introduce empty `assets/avatars` and `assets/items` directories
- expand container styling for full screen gameplay and add avatar themed backgrounds
- show random item previews in the shop
- lower dodge and defense chances for better balance
- add background change and preview related scripts
- update README to explain using the assets folders

## Testing
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_684a43f455e483278adda5e5da75f5b4