### PR TITLE
Implement per-avatar leveling and coin display

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,20 @@
+{
+  "weapon": {
+    "common": ["Rusty Sword", "Wooden Club", "Simple Dagger", "Bronze Axe", "Oak Spear"],
+    "rare": ["Steel Blade", "Enchanted Bow", "Warhammer", "Silver Rapier", "Runic Spear"],
+    "epic": ["Dragon Slayer", "Arcane Staff", "Shadow Blade", "Celestial Edge", "Doom Hammer"],
+    "legendary": ["Excalibur", "Divine Halberd", "Demonbane", "Storm Bringer", "Celestial Katana"]
+  },
+  "armor": {
+    "common": ["Leather Armor", "Wooden Shield", "Cloth Robe", "Padded Vest", "Hide Coat"],
+    "rare": ["Chainmail", "Iron Shield", "Mage Cloak", "Knight Plate", "Scaled Mail"],
+    "epic": ["Dragon Scale", "Blessed Aegis", "Shadow Garb", "Guardian Plate", "Ethereal Shroud"],
+    "legendary": ["Aegis of Eternity", "Mythic Plate", "Dragonskin Mail", "Archmage Robe", "Shadow Emperor Armor"]
+  },
+  "artifact": {
+    "common": ["Minor Talisman", "Old Charm", "Traveler's Stone", "Lucky Coin", "Tiny Totem"],
+    "rare": ["Mystic Amulet", "Guardian Rune", "Sorcerer's Orb", "Dragon Eye", "Moon Pendant"],
+    "epic": ["Phoenix Heart", "Ancient Relic", "Time Shard", "Star Fragment", "Valkyrie Sigil"],
+    "legendary": ["Orb of Infinity", "Eternal Crown", "Dragon God's Eye", "Celestial Phoenix Feather", "Time Warp Relic"]
+  }
+}

--- a/game.js
+++ b/game.js
@@ -3,23 +3,11 @@ let avatarsLoaded = false;
 fetch("data/avatars.json")
   .then(r => r.json())
   .then(data => { avatars = data; avatarsLoaded = true; });
-const itemNames={
-    weapon:{
-        common:['Rusty Sword','Wooden Club','Simple Dagger','Bronze Axe','Oak Spear'],
-        rare:['Steel Blade','Enchanted Bow','Warhammer','Silver Rapier','Runic Spear'],
-        epic:['Dragon Slayer','Arcane Staff','Shadow Blade','Celestial Edge','Doom Hammer']
-    },
-    armor:{
-        common:['Leather Armor','Wooden Shield','Cloth Robe','Padded Vest','Hide Coat'],
-        rare:['Chainmail','Iron Shield','Mage Cloak','Knight Plate','Scaled Mail'],
-        epic:['Dragon Scale','Blessed Aegis','Shadow Garb','Guardian Plate','Ethereal Shroud']
-    },
-    artifact:{
-        common:['Minor Talisman','Old Charm','Traveler\'s Stone','Lucky Coin','Tiny Totem'],
-        rare:['Mystic Amulet','Guardian Rune','Sorcerer\'s Orb','Dragon Eye','Moon Pendant'],
-        epic:['Phoenix Heart','Ancient Relic','Time Shard','Star Fragment','Valkyrie Sigil']
-    }
-};
+let itemNames = {};
+let itemsLoaded = false;
+fetch("data/items.json")
+  .then(r => r.json())
+  .then(data => { itemNames = data; itemsLoaded = true; });
 const backgrounds={
     Knight:'knight-bg',
     Mage:'mage-bg',
@@ -39,15 +27,20 @@ let cooldown=[0,0];
 let cooldownBase=[3,3];
 let coins=0;
 let inventory={
-    weapon:{common:[],rare:[],epic:[]},
-    armor:{common:[],rare:[],epic:[]},
-    artifact:{common:[],rare:[],epic:[]}
+    weapon:{common:[],rare:[],epic:[],legendary:[]},
+    armor:{common:[],rare:[],epic:[],legendary:[]},
+    artifact:{common:[],rare:[],epic:[],legendary:[]}
 };
 let xp=0;
-let level=1;
+let level=0;
+let xpData={Knight:{xp:0,level:0},Mage:{xp:0,level:0},Rogue:{xp:0,level:0}};
+let currentAvatar=null;
 let cpuCoins=0;
 let battleNumber=1;
 let isBoss=false;
+let currentBattleIsBoss=false;
+let lastRewardCoins=0;
+let lastLootMsg='';
 const log=document.getElementById('log');
 function logMsg(msg){log.innerHTML+=msg+'<br>';log.scrollTop=log.scrollHeight;}
 
@@ -63,17 +56,19 @@ function setButtons(enabled){
 function saveProgress(){
     localStorage.setItem('aaCoins', coins);
     localStorage.setItem('aaInv', JSON.stringify(inventory));
-    localStorage.setItem('aaXP', xp);
-    localStorage.setItem('aaLevel', level);
+    localStorage.setItem('aaXPData', JSON.stringify(xpData));
 }
 
 function loadProgress(){
     const saved=localStorage.getItem('aaCoins');
     if(saved) coins=parseInt(saved);
-    const savedXP=localStorage.getItem('aaXP');
-    if(savedXP) xp=parseInt(savedXP);
-    const savedLvl=localStorage.getItem('aaLevel');
-    if(savedLvl) level=parseInt(savedLvl);
+    const xpStr=localStorage.getItem('aaXPData');
+    if(xpStr){
+        try{ xpData=JSON.parse(xpStr); }catch(e){}
+    }
+    for(const av of ['Knight','Mage','Rogue']){
+        if(!xpData[av]) xpData[av]={xp:0,level:0};
+    }
     const inv=localStorage.getItem('aaInv');
     if(inv){
         const data=JSON.parse(inv);
@@ -81,10 +76,14 @@ function loadProgress(){
             inventory=data;
         }else{
             inventory={
-                weapon:{common:Array(data.weapon).fill('Common Weapon'),rare:[],epic:[]},
-                armor:{common:Array(data.armor).fill('Common Armor'),rare:[],epic:[]},
-                artifact:{common:Array(data.artifact).fill('Common Artifact'),rare:[],epic:[]}
+                weapon:{common:Array(data.weapon).fill('Common Weapon'),rare:[],epic:[],legendary:[]},
+                armor:{common:Array(data.armor).fill('Common Armor'),rare:[],epic:[],legendary:[]},
+                artifact:{common:Array(data.artifact).fill('Common Artifact'),rare:[],epic:[],legendary:[]}
             };
+        }
+        // ensure new legendary arrays exist
+        for(const cat of ['weapon','armor','artifact']){
+            if(!inventory[cat].legendary) inventory[cat].legendary=[];
         }
     }
 }
@@ -94,6 +93,8 @@ function updateCoins(){
     if(coinEl) coinEl.textContent=coins;
     const el=document.getElementById('coins-loadout');
     if(el) el.textContent=coins;
+    const top=document.getElementById('coins-top');
+    if(top) top.textContent=coins;
     const lvl=document.getElementById('level');
     const xpEl=document.getElementById('xp');
     if(lvl) lvl.textContent=level;
@@ -102,19 +103,31 @@ function updateCoins(){
     updateInventoryUI();
 }
 
+function showBack(){
+    const btn=document.getElementById('menu-back');
+    if(btn) btn.classList.remove('hidden');
+}
+function hideBack(){
+    const btn=document.getElementById('menu-back');
+    if(btn) btn.classList.add('hidden');
+}
+
 function updateInventoryUI(){
     const w=document.getElementById('inv-weapon');
     const a=document.getElementById('inv-armor');
     const t=document.getElementById('inv-artifact');
     if(w) w.textContent=`Common:${inventory.weapon.common.length} `+
         `Rare:${inventory.weapon.rare.length} `+
-        `Epic:${inventory.weapon.epic.length}`;
+        `Epic:${inventory.weapon.epic.length} `+
+        `Legendary:${inventory.weapon.legendary.length}`;
     if(a) a.textContent=`Common:${inventory.armor.common.length} `+
         `Rare:${inventory.armor.rare.length} `+
-        `Epic:${inventory.armor.epic.length}`;
+        `Epic:${inventory.armor.epic.length} `+
+        `Legendary:${inventory.armor.legendary.length}`;
     if(t) t.textContent=`Common:${inventory.artifact.common.length} `+
         `Rare:${inventory.artifact.rare.length} `+
-        `Epic:${inventory.artifact.epic.length}`;
+        `Epic:${inventory.artifact.epic.length} `+
+        `Legendary:${inventory.artifact.legendary.length}`;
 }
 
 function updateEquipInfo(){
@@ -145,12 +158,18 @@ document.querySelectorAll('.avatar-grid button').forEach(btn=>{
         const avatar=btn.dataset.avatar;
         const data=avatars[avatar];
         if(!data) return;
+        currentAvatar=avatar;
+        const info=xpData[avatar]||{xp:0,level:0};
+        xp=info.xp;
+        level=info.level;
         players[0]={
             ...data,
             name:`Player (${data.emoji} ${avatar})`,
-            maxHp:data.hp,
+            maxHp:data.hp + level*5,
             maxEnergy:data.energy,
             energy:data.energy,
+            atk:data.atk + level,
+            def:data.def + level,
             img:`assets/avatars/${avatar.toLowerCase()}.png`,
             equipment:{weapon:[],armor:[],artifact:[]},
             slots:data.slots
@@ -163,6 +182,7 @@ document.querySelectorAll('.avatar-grid button').forEach(btn=>{
 function showLoadout(){
     document.getElementById('selection-screen').classList.add('hidden');
     document.getElementById('loadout-screen').classList.remove('hidden');
+    showBack();
     document.getElementById('loadout-name').textContent=players[0].name;
     document.getElementById('loadout-model').innerHTML=`<img src="${players[0].img}" class="battle-img">`;
     document.getElementById('loadout-stats').textContent=`HP: ${players[0].maxHp} ATK: ${players[0].atk} DEF: ${players[0].def}`;
@@ -179,11 +199,17 @@ function startBattle(){
     document.getElementById('victory-screen').classList.add('hidden');
     document.getElementById('defeat-screen').classList.add('hidden');
     document.getElementById('battle-screen').classList.remove('hidden');
+    showBack();
     const keys=Object.keys(avatars);
     const enemyKey=keys[Math.floor(Math.random()*keys.length)];
+    currentBattleIsBoss=isBoss;
+    const baseName=currentBattleIsBoss?(
+        enemyKey==='Rogue'? 'Renegade Rogue':
+        enemyKey==='Knight'? 'Mega Knight':'Master Mage'
+    ):`CPU (${avatars[enemyKey].emoji} ${enemyKey})`;
     players[1]={
         ...avatars[enemyKey],
-        name:`CPU (${avatars[enemyKey].emoji} ${enemyKey})`,
+        name:baseName,
         maxHp:avatars[enemyKey].hp,
         maxEnergy:avatars[enemyKey].energy,
         energy:avatars[enemyKey].energy,
@@ -191,7 +217,7 @@ function startBattle(){
         equipment:{weapon:[],armor:[],artifact:[]},
         slots:avatars[enemyKey].slots
     };
-    if(isBoss){
+    if(currentBattleIsBoss){
         players[1].maxHp=Math.round(players[1].maxHp*2);
         players[1].atk=Math.round(players[1].atk*1.5);
         players[1].def=Math.round(players[1].def*1.5);
@@ -397,10 +423,14 @@ function checkVictory(){
             document.getElementById('victory-screen').classList.remove('hidden');
             document.getElementById('defeat-screen').classList.add('hidden');
             document.getElementById('winner').textContent=`${players[0].name} Wins!`;
-            coins+=20;
+            const reward=currentBattleIsBoss?20:10;
+            lastRewardCoins=reward;
+            coins+=reward;
             cpuCoins+=10;
-            logMsg('You earned 20 coins!');
-            tryLoot();
+            logMsg(`You earned ${reward} coins!`);
+            lastLootMsg=tryLoot();
+            document.getElementById('victory-img').src=players[0].img;
+            document.getElementById('victory-reward').textContent=`+${reward} coins. ${lastLootMsg}`;
             addXP(50);
             document.getElementById('next-btn').classList.remove('hidden');
             showConfetti();
@@ -408,13 +438,18 @@ function checkVictory(){
             document.getElementById('victory-screen').classList.add('hidden');
             document.getElementById('defeat-screen').classList.remove('hidden');
             document.getElementById('loser').textContent=`Defeated by ${players[1].name}`;
-            coins+=10;
+            lastRewardCoins=5;
+            coins+=5;
             cpuCoins+=20;
-            logMsg('You earned 10 coins.');
+            lastLootMsg='';
+            logMsg('You earned 5 coins.');
+            document.getElementById('defeat-img').src=players[1].img;
+            document.getElementById('defeat-reward').textContent=`+5 coins.`;
             document.getElementById('next-btn').classList.add('hidden');
         }
         updateCoins();
         updateEquipInfo();
+        currentBattleIsBoss=false;
         return true;
     }
     return false;
@@ -435,9 +470,12 @@ function equipWeapon(){
     const name=randomItemName('weapon',rarity);
     players[0].equipment.weapon.push(name);
     inventory.weapon[rarity].push(name);
-    players[0].atk+=rarity==='epic'?4:rarity==='rare'?3:2;
+    players[0].atk+=rarity==='legendary'?8:rarity==='epic'?6:rarity==='rare'?4:2;
     logMsg(`Equipped ${colorName(name,rarity)}.`);
     updateCoins();
+    updateEquipInfo();
+    updateLoadout();
+    updateUI();
 }
 function equipArmor(){
     if(players[0].equipment.armor.length>=players[0].slots.armor){
@@ -448,9 +486,12 @@ function equipArmor(){
     const name=randomItemName('armor',rarity);
     players[0].equipment.armor.push(name);
     inventory.armor[rarity].push(name);
-    players[0].def+=rarity==='epic'?4:rarity==='rare'?3:2;
+    players[0].def+=rarity==='legendary'?8:rarity==='epic'?6:rarity==='rare'?4:2;
     logMsg(`Equipped ${colorName(name,rarity)}.`);
     updateCoins();
+    updateEquipInfo();
+    updateLoadout();
+    updateUI();
 }
 function equipArtifact(){
     if(players[0].equipment.artifact.length>=players[0].slots.artifact){
@@ -461,23 +502,29 @@ function equipArtifact(){
     const name=randomItemName('artifact',rarity);
     players[0].equipment.artifact.push(name);
     inventory.artifact[rarity].push(name);
-    if(rarity==='epic'){cooldownBase[0]=Math.max(1,cooldownBase[0]-3);players[0].maxHp+=30;players[0].maxEnergy+=15;}
+    if(rarity==='legendary'){cooldownBase[0]=Math.max(1,cooldownBase[0]-4);players[0].maxHp+=40;players[0].maxEnergy+=20;}
+    else if(rarity==='epic'){cooldownBase[0]=Math.max(1,cooldownBase[0]-3);players[0].maxHp+=30;players[0].maxEnergy+=15;}
     else if(rarity==='rare'){cooldownBase[0]=Math.max(1,cooldownBase[0]-2);players[0].maxHp+=20;players[0].maxEnergy+=10;}
     else {cooldownBase[0]=Math.max(1,cooldownBase[0]-1);players[0].maxHp+=10;players[0].maxEnergy+=5;}
     players[0].energy=players[0].maxEnergy;
     logMsg(`Equipped ${colorName(name,rarity)}.`);
     updateCoins();
+    updateEquipInfo();
+    updateLoadout();
+    updateUI();
 }
 
 function randomRarity(){
     const roll=Math.random();
-    if(roll<0.6) return 'common';
-    if(roll<0.9) return 'rare';
-    return 'epic';
+    if(roll<0.5) return 'common';
+    if(roll<0.8) return 'rare';
+    if(roll<0.95) return 'epic';
+    return 'legendary';
 }
 
 function randomItemName(type,rarity){
-    const list=itemNames[type][rarity];
+    const list=itemNames[type]?.[rarity]||[];
+    if(!list.length) return 'Unknown';
     return list[Math.floor(Math.random()*list.length)];
 }
 
@@ -503,41 +550,52 @@ function buyArtifact(){ purchase('artifact',20); }
 function giveRandomLoot(){
     const typeRoll=Math.random();
     const rarity=randomRarity();
+    let msg='';
     if(typeRoll<0.33){
         const name=randomItemName('weapon',rarity);
         inventory.weapon[rarity].push(name);
-        logMsg(`Found ${colorName(name,rarity)}!`);
+        msg=`Found ${name} (${rarity.charAt(0).toUpperCase()+rarity.slice(1)})!`;
+        logMsg(colorName(msg,rarity));
     }else if(typeRoll<0.66){
         const name=randomItemName('armor',rarity);
         inventory.armor[rarity].push(name);
-        logMsg(`Found ${colorName(name,rarity)}!`);
+        msg=`Found ${name} (${rarity.charAt(0).toUpperCase()+rarity.slice(1)})!`;
+        logMsg(colorName(msg,rarity));
     }else{
         const name=randomItemName('artifact',rarity);
         inventory.artifact[rarity].push(name);
-        logMsg(`Found ${colorName(name,rarity)}!`);
+        msg=`Found ${name} (${rarity.charAt(0).toUpperCase()+rarity.slice(1)})!`;
+        logMsg(colorName(msg,rarity));
     }
     updateCoins();
+    return msg;
 }
 
 function tryLoot(){
     if(Math.random()<0.3){
-        giveRandomLoot();
+        return giveRandomLoot();
     }else{
-        logMsg('No drops this time.');
+        const msg='No drops this time.';
+        logMsg(msg);
+        return msg;
     }
 }
 
 function addXP(amount){
     xp+=amount;
-    const needed=level*100;
-    if(xp>=needed){
-        xp-=needed;
+    while(xp>=100){
+        xp-=100;
         level++;
-        players[0].maxHp+=10;
-        players[0].maxEnergy+=5;
+        players[0].atk+=1;
+        players[0].def+=1;
+        players[0].maxHp+=5;
+        players[0].hp+=5;
         logMsg(`Level up! Now level ${level}.`);
     }
+    xpData[currentAvatar]={xp,level};
     updateCoins();
+    updateLoadout();
+    updateUI();
 }
 
 function closeShop(){
@@ -547,6 +605,7 @@ function closeShop(){
 function showCustom(){
     document.getElementById('loadout-screen').classList.add('hidden');
     document.getElementById('custom-screen').classList.remove('hidden');
+    showBack();
     populateCustom();
 }
 
@@ -574,9 +633,9 @@ function populateCustom(){
     const aSel=document.getElementById('armor-select');
     const tSel=document.getElementById('artifact-select');
     const fill=(sel,arr)=>{ sel.innerHTML=''; arr.forEach(n=>{const o=document.createElement('option');o.textContent=n;sel.appendChild(o);}); };
-    fill(wSel,[...inventory.weapon.common,...inventory.weapon.rare,...inventory.weapon.epic]);
-    fill(aSel,[...inventory.armor.common,...inventory.armor.rare,...inventory.armor.epic]);
-    fill(tSel,[...inventory.artifact.common,...inventory.artifact.rare,...inventory.artifact.epic]);
+    fill(wSel,[...inventory.weapon.common,...inventory.weapon.rare,...inventory.weapon.epic,...inventory.weapon.legendary]);
+    fill(aSel,[...inventory.armor.common,...inventory.armor.rare,...inventory.armor.epic,...inventory.armor.legendary]);
+    fill(tSel,[...inventory.artifact.common,...inventory.artifact.rare,...inventory.artifact.epic,...inventory.artifact.legendary]);
 }
 
 function equipSelected(type){
@@ -585,7 +644,7 @@ function equipSelected(type){
     if(!name) return;
     const inv=inventory[type];
     let rarity='';
-    for(const r of ['epic','rare','common']){
+    for(const r of ['legendary','epic','rare','common']){
         const idx=inv[r].indexOf(name);
         if(idx>-1){inv[r].splice(idx,1);rarity=r;break;}
     }
@@ -593,10 +652,15 @@ function equipSelected(type){
     const p=players[0];
     if(p.equipment[type].length>=p.slots[type]){logMsg('No '+type+' slots left.'); return;}
     p.equipment[type].push(name);
-    if(type==='weapon') p.atk+=rarity==='epic'?4:rarity==='rare'?3:2;
-    if(type==='armor') p.def+=rarity==='epic'?4:rarity==='rare'?3:2;
+    if(type==='weapon'){
+        p.atk+=rarity==='legendary'?8:rarity==='epic'?6:rarity==='rare'?4:2;
+    }
+    if(type==='armor'){
+        p.def+=rarity==='legendary'?8:rarity==='epic'?6:rarity==='rare'?4:2;
+    }
     if(type==='artifact'){
-        if(rarity==='epic'){cooldownBase[0]=Math.max(1,cooldownBase[0]-3);p.maxHp+=30;p.maxEnergy+=15;}
+        if(rarity==='legendary'){cooldownBase[0]=Math.max(1,cooldownBase[0]-4);p.maxHp+=40;p.maxEnergy+=20;}
+        else if(rarity==='epic'){cooldownBase[0]=Math.max(1,cooldownBase[0]-3);p.maxHp+=30;p.maxEnergy+=15;}
         else if(rarity==='rare'){cooldownBase[0]=Math.max(1,cooldownBase[0]-2);p.maxHp+=20;p.maxEnergy+=10;}
         else {cooldownBase[0]=Math.max(1,cooldownBase[0]-1);p.maxHp+=10;p.maxEnergy+=5;}
         p.energy=p.maxEnergy;
@@ -610,9 +674,12 @@ function equipSelected(type){
 
 function goBack(){
     document.getElementById('loadout-screen').classList.add('hidden');
+    document.getElementById('custom-screen').classList.add('hidden');
+    document.getElementById('battle-screen').classList.add('hidden');
     document.getElementById('victory-screen').classList.add('hidden');
     document.getElementById('defeat-screen').classList.add('hidden');
     document.getElementById('selection-screen').classList.remove('hidden');
+    hideBack();
 }
 
 function startBossBattle(){
@@ -633,11 +700,13 @@ function showConfetti(){
 }
 
 function previewItem(type){
+    if(!itemsLoaded) return;
     const rarity=randomRarity();
     const name=randomItemName(type,rarity);
     nextPurchase[type]={name,rarity};
     document.getElementById(`buy-${type}-btn`).title=name;
-    document.getElementById('preview').innerHTML=colorName(name,rarity);
+    const rarityLabel=rarity.charAt(0).toUpperCase()+rarity.slice(1);
+    document.getElementById('preview').innerHTML=colorName(`${name} (${rarityLabel})`,rarity);
 }
 
 function clearPreview(e){
@@ -656,7 +725,7 @@ document.getElementById('next-btn').onclick=nextBattle;
 document.getElementById('shop-btn').onclick=()=>{
     document.getElementById('shop-screen').classList.toggle('hidden');
 };
-document.getElementById('back-btn').onclick=goBack;
+document.getElementById('menu-back').onclick=goBack;
 document.getElementById('boss-btn').onclick=startBossBattle;
 document.getElementById('custom-btn').onclick=showCustom;
 document.getElementById('custom-back').onclick=hideCustom;

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
 </head>
 <body>
 <div class="container">
+    <div id="coin-display">🪙 <span id="coins-top">0</span></div>
+    <button id="menu-back" class="top-right hidden">🔙 Back</button>
     <div id="selection-screen">
         <h1>Choose Your Avatar</h1>
         <div class="avatar-grid">
@@ -41,11 +43,7 @@
                 Artifacts: <span id="inv-artifact">0</span>
             </div>
             <div id="equip-info-loadout"></div>
-            <button onclick="equipWeapon()">Equip Weapon</button>
-            <button onclick="equipArmor()">Equip Armor</button>
-            <button onclick="equipArtifact()">Equip Artifact</button>
             <button id="shop-btn">🛒 Shop</button>
-            <button id="back-btn">🔙 Back</button>
         </div>
         <div id="shop-screen" class="hidden">
             <h3>Shop</h3>
@@ -86,14 +84,6 @@
     <div id="battle-screen" class="hidden">
         <h2 id="turn-indicator"></h2>
         <div class="battle-area">
-            <div class="player" id="player2">
-                <h3 id="p2-name"></h3>
-                <div class="model" id="p2-model"></div>
-                <div class="health-bar"><div class="health-inner" id="p2-health"></div></div>
-                <div class="energy-bar"><div class="energy-inner" id="p2-energy"></div></div>
-                <p id="p2-stats"></p>
-                <p id="p2-equip"></p>
-            </div>
             <div class="player" id="player1">
                 <h3 id="p1-name"></h3>
                 <div class="model" id="p1-model"></div>
@@ -101,6 +91,14 @@
                 <div class="energy-bar"><div class="energy-inner" id="p1-energy"></div></div>
                 <p id="p1-stats"></p>
                 <p id="p1-equip"></p>
+            </div>
+            <div class="player" id="player2">
+                <h3 id="p2-name"></h3>
+                <div class="model" id="p2-model"></div>
+                <div class="health-bar"><div class="health-inner" id="p2-health"></div></div>
+                <div class="energy-bar"><div class="energy-inner" id="p2-energy"></div></div>
+                <p id="p2-stats"></p>
+                <p id="p2-equip"></p>
             </div>
         </div>
         <div class="actions">
@@ -112,11 +110,15 @@
         </div>
     <div id="victory-screen" class="hidden end-screen">
         <h1 id="winner"></h1>
+        <img id="victory-img" class="result-img" src="" alt="winner">
+        <p id="victory-reward"></p>
         <button id="next-btn" class="hidden">▶️ Next Battle</button>
         <button onclick="location.reload()">🔄 Restart</button>
     </div>
     <div id="defeat-screen" class="hidden end-screen">
         <h1 id="loser"></h1>
+        <img id="defeat-img" class="result-img" src="" alt="loser">
+        <p id="defeat-reward"></p>
         <button onclick="location.reload()">🔄 Restart</button>
     </div>
 </div>

--- a/style.css
+++ b/style.css
@@ -25,6 +25,13 @@ button{
     box-sizing:border-box;
     background:#fff;
     color:#000;
+    position:relative;
+}
+.top-right{
+    position:absolute;
+    top:10px;
+    right:10px;
+    z-index:10;
 }
 .hidden{display:none!important;}
 .avatar-grid{
@@ -45,7 +52,7 @@ button{
 }
 .avatar-img{
     width:100%;
-    height:220px;
+    aspect-ratio:1/1;
     margin-bottom:10px;
     background:#ccc;
     object-fit:contain;
@@ -77,6 +84,13 @@ button{
     height:220px;
     object-fit:contain;
     margin-bottom:5px;
+}
+.result-img{
+    width:120px;
+    height:120px;
+    object-fit:contain;
+    margin:10px auto;
+    display:block;
 }
 .health-bar{
     height:20px;
@@ -147,8 +161,22 @@ button{
     color:#d4af37;
     font-weight:bold;
 }
+#coin-display{
+    position:absolute;
+    top:10px;
+    right:70px;
+    color:#d4af37;
+    font-weight:bold;
+}
 #coins-area-loadout button{
     margin:5px 10px;
+}
+#inventory-info{
+    border:2px solid #333;
+    padding:5px;
+    margin:5px 0;
+    display:inline-block;
+    background:#f7f7f7;
 }
 #shop-screen{
     margin-top:10px;
@@ -170,8 +198,12 @@ button{
     font-style:italic;
 }
 .rarity-common{color:#666;}
-.rarity-rare{color:#2ecc71;}
-.rarity-epic{color:#f1c40f;}
+.rarity-rare{color:#3498db;}
+.rarity-epic{color:#9b59b6;}
+.rarity-legendary{color:#f1c40f;}
+
+#p1-name{color:#0a0;}
+#p2-name{color:#a00;}
 
 body.knight-bg{
     background:linear-gradient(#d4d4d4,#a0a0a0);
@@ -203,7 +235,7 @@ body.rogue-bg{
     }
     .avatar-img{
         width:100%;
-        height:180px;
+        aspect-ratio:1/1;
         object-fit:contain;
     }
     .avatar-list button{


### PR DESCRIPTION
## Summary
- store XP per avatar and load level bonuses on selection
- add global coin display to top-right of UI
- move item names into `data/items.json`
- fetch item data and guard shop preview until loaded
- grant +1 ATK/DEF and +5 HP on each level up

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b9a48b57c832798c2695799c511b1